### PR TITLE
[IIIF-419] Add NAT feature as optional, and private-only subnets to be included

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -70,17 +70,17 @@ resource "aws_route_table" "route_table_private_nat" {
   }
 }
 
-#resource "aws_route_table_association" "nat_route_private_subnets" {
-#  for_each  = (var.enable_nat > 0 ? toset(aws_subnet.private.*.id) : [])
-#  subnet_id = each.key
-#  route_table_id = "${aws_route_table.route_table_private_nat[0].id}"
-#}
-
-resource "aws_route_table_association" "override_nat_route_private_subnets" {
-  for_each  = (var.associate_existing_nat > 0 ? toset(aws_subnet.private.*.id) : [])
+resource "aws_route_table_association" "nat_route_private_subnets" {
+  for_each  = (var.enable_nat > 0 ? toset(aws_subnet.private.*.id) : [])
   subnet_id = each.key
-  route_table_id = "${var.existing_private_nat_gateway_id}"
+  route_table_id = "${aws_route_table.route_table_private_nat[0].id}"
 }
+
+#resource "aws_route_table_association" "override_nat_route_private_subnets" {
+#  for_each  = (var.associate_existing_nat > 0 ? toset(aws_subnet.private.*.id) : [])
+#  subnet_id = each.key
+#  route_table_id = "${var.existing_private_nat_gateway_id}"
+#}
 
 resource "aws_vpc_endpoint" "s3" {
   count        = "${var.create_vpc_endpoint > 0 ? 1 : 0}"

--- a/main.tf
+++ b/main.tf
@@ -44,8 +44,8 @@ resource "aws_route_table" "route_table_ig_gw" {
 }
 
 resource "aws_route_table_association" "route_public_subnets" {
-  count = "${var.public_subnet_count}"
-  subnet_id = "${aws_subnet.public[count.index - 1].id}"
+  for_each = toset(aws_subnet.public.*.id)
+  subnet_id = each.key
   route_table_id = "${aws_route_table.route_table_ig_gw.id}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,7 @@ resource "aws_route_table" "route_table_ig_gw" {
 
 resource "aws_route_table_association" "route_public_subnets" {
   count = "${var.public_subnet_count}"
-  subnet_id = "${aws_subnet.public[count.index]}"
+  subnet_id = "${aws_subnet.public[count.index - 1].id}"
   route_table_id = "${aws_route_table.route_table_ig_gw.id}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -76,11 +76,11 @@ resource "aws_route_table_association" "nat_route_private_subnets" {
   route_table_id = "${aws_route_table.route_table_private_nat[0].id}"
 }
 
-#resource "aws_route_table_association" "override_nat_route_private_subnets" {
-#  for_each  = (var.associate_existing_nat > 0 ? toset(aws_subnet.private.*.id) : [])
-#  subnet_id = each.key
-#  route_table_id = "${var.existing_private_nat_gateway_id}"
-#}
+resource "aws_route_table_association" "override_nat_route_private_subnets" {
+  for_each  = (var.associate_existing_nat > 0 ? toset(aws_subnet.private.*.id) : [])
+  subnet_id = each.key
+  route_table_id = "${var.existing_private_nat_gateway_id != "" ? var.existing_private_nat_gateway_id : aws_route_table.route_table_private_nat[0].id}"
+}
 
 resource "aws_vpc_endpoint" "s3" {
   count        = "${var.create_vpc_endpoint > 0 ? 1 : 0}"

--- a/main.tf
+++ b/main.tf
@@ -76,11 +76,11 @@ resource "aws_route_table_association" "nat_route_private_subnets" {
   route_table_id = "${aws_route_table.route_table_private_nat[0].id}"
 }
 
-#resource "aws_route_table_association" "override_nat_route_private_subnets" {
-#  for_each  = var.associate_existing_nat > 0 ? toset(aws_subnet.private.*.id) : []
-#  subnet_id = each.key
-#  route_table_id = "${var.existing_private_nat_gateway_id}"
-#}
+resource "aws_route_table_association" "override_nat_route_private_subnets" {
+  for_each  = (var.associate_existing_nat > 0 ? toset(aws_subnet.private.*.id) : [])
+  subnet_id = each.key
+  route_table_id = "${var.existing_private_nat_gateway_id}"
+}
 
 resource "aws_vpc_endpoint" "s3" {
   count        = "${var.create_vpc_endpoint > 0 ? 1 : 0}"

--- a/main.tf
+++ b/main.tf
@@ -70,17 +70,16 @@ resource "aws_route_table" "route_table_private_nat" {
   }
 }
 
-resource "aws_route_table_association" "nat_route_private_subnets" {
-  for_each  = (var.enable_nat > 0 ? toset(aws_subnet.private.*.id) : [])
-  subnet_id = each.key
-  route_table_id = "${aws_route_table.route_table_private_nat[0].id}"
-}
+#resource "aws_route_table_association" "nat_route_private_subnets" {
+#  for_each  = (var.enable_nat > 0 ? toset(aws_subnet.private.*.id) : [])
+#  subnet_id = each.key
+#  route_table_id = "${aws_route_table.route_table_private_nat[0].id}"
+#}
 
 resource "aws_route_table_association" "override_nat_route_private_subnets" {
   for_each  = (var.associate_existing_nat > 0 ? toset(aws_subnet.private.*.id) : [])
   subnet_id = each.key
-  route_table_id = "${aws_route_table.route_table_private_nat[0].id}"
-#  route_table_id = "${var.existing_private_nat_gateway_id}"
+  route_table_id = "${var.existing_private_nat_gateway_id}"
 }
 
 resource "aws_vpc_endpoint" "s3" {

--- a/main.tf
+++ b/main.tf
@@ -76,3 +76,9 @@ resource "aws_route_table_association" "route_private_subnets" {
   route_table_id = "${aws_route_table.route_table_private_nat[0].id}"
 }
 
+resource "aws_vpc_endpoint" "s3" {
+  count        = "${var.create_vpc_endpoint > 0 ? 1 : 0}"
+  vpc_id       = "${aws_vpc.main.id}"
+  service_name = "${var.vpc_endpoint}"
+}
+

--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,7 @@ resource "aws_route_table" "route_table_ig_gw" {
 
 resource "aws_route_table_association" "route_public_subnets" {
   count = "${var.public_subnet_count}"
-  subnet_id = "${aws_subnet.public[count.index - 1]}"
+  subnet_id = "${aws_subnet.public[count.index]}"
   route_table_id = "${aws_route_table.route_table_ig_gw.id}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -70,11 +70,11 @@ resource "aws_route_table" "route_table_private_nat" {
   }
 }
 
-resource "aws_route_table_association" "nat_route_private_subnets" {
-  for_each  = (var.enable_nat > 0 ? toset(aws_subnet.private.*.id) : [])
-  subnet_id = each.key
-  route_table_id = "${aws_route_table.route_table_private_nat[0].id}"
-}
+#resource "aws_route_table_association" "nat_route_private_subnets" {
+#  for_each  = (var.enable_nat > 0 ? toset(aws_subnet.private.*.id) : [])
+#  subnet_id = each.key
+#  route_table_id = "${aws_route_table.route_table_private_nat[0].id}"
+#}
 
 resource "aws_route_table_association" "override_nat_route_private_subnets" {
   for_each  = (var.associate_existing_nat > 0 ? toset(aws_subnet.private.*.id) : [])

--- a/main.tf
+++ b/main.tf
@@ -61,3 +61,18 @@ resource "aws_nat_gateway" "private_nat_gw" {
   depends_on = ["aws_internet_gateway.gw"]
 }
 
+resource "aws_route_table" "route_table_private_nat" {
+  count = "${var.private_subnet_count > 0 ? 1 : 0}"
+  vpc_id = "${aws_vpc.main.id}"
+  route {
+    cidr_block = "0.0.0.0/0"
+    nat_gateway_id = "${aws_nat_gateway.private_nat_gw[0].id}"
+  }
+}
+
+resource "aws_route_table_association" "route_private_subnets" {
+  for_each = toset(aws_subnet.private.*.id)
+  subnet_id = each.key
+  route_table_id = "${aws_route_table.route_table_private_nat[0].id}"
+}
+

--- a/main.tf
+++ b/main.tf
@@ -76,6 +76,13 @@ resource "aws_route_table_association" "dynamic_nat_route_private_subnets" {
   route_table_id = "${aws_route_table.route_table_private_nat[0].id}"
 }
 
+resource "aws_route_table_association" "override_nat_route_private_subnets" {
+  for_each  = var.associate_existing_nat > 0 ? toset(aws_subnet.private.*.id) : []
+  subnet_id = each.key
+  route_table_id = "${aws_route_table.route_table_private_nat[0].id}"
+}
+
+
 #resource "aws_route_table_association" "override_nat_route_private_subnets" {
 #  for_each  = var.associate_existing_nat > 0 ? toset(aws_subnet.private.*.id) : []
 #  subnet_id = each.key

--- a/main.tf
+++ b/main.tf
@@ -70,18 +70,11 @@ resource "aws_route_table" "route_table_private_nat" {
   }
 }
 
-resource "aws_route_table_association" "dynamic_nat_route_private_subnets" {
-  for_each  = var.enable_nat > 0 ? toset(aws_subnet.private.*.id) : []
+resource "aws_route_table_association" "nat_route_private_subnets" {
+  for_each  = (var.enable_nat > 0 ? toset(aws_subnet.private.*.id) : [])
   subnet_id = each.key
   route_table_id = "${aws_route_table.route_table_private_nat[0].id}"
 }
-
-resource "aws_route_table_association" "override_nat_route_private_subnets" {
-  for_each  = var.associate_existing_nat > 0 ? toset(aws_subnet.private.*.id) : []
-  subnet_id = each.key
-  route_table_id = "${aws_route_table.route_table_private_nat[0].id}"
-}
-
 
 #resource "aws_route_table_association" "override_nat_route_private_subnets" {
 #  for_each  = var.associate_existing_nat > 0 ? toset(aws_subnet.private.*.id) : []

--- a/main.tf
+++ b/main.tf
@@ -70,11 +70,11 @@ resource "aws_route_table" "route_table_private_nat" {
   }
 }
 
-#resource "aws_route_table_association" "nat_route_private_subnets" {
-#  for_each  = (var.enable_nat > 0 ? toset(aws_subnet.private.*.id) : [])
-#  subnet_id = each.key
-#  route_table_id = "${aws_route_table.route_table_private_nat[0].id}"
-#}
+resource "aws_route_table_association" "nat_route_private_subnets" {
+  for_each  = (var.enable_nat > 0 ? toset(aws_subnet.private.*.id) : [])
+  subnet_id = each.key
+  route_table_id = "${aws_route_table.route_table_private_nat[0].id}"
+}
 
 resource "aws_route_table_association" "override_nat_route_private_subnets" {
   for_each  = (var.associate_existing_nat > 0 ? toset(aws_subnet.private.*.id) : [])

--- a/main.tf
+++ b/main.tf
@@ -70,10 +70,16 @@ resource "aws_route_table" "route_table_private_nat" {
   }
 }
 
-resource "aws_route_table_association" "route_private_subnets" {
+resource "aws_route_table_association" "dynamic_nat_route_private_subnets" {
   for_each  = var.enable_nat > 0 ? toset(aws_subnet.private.*.id) : []
   subnet_id = each.key
   route_table_id = "${aws_route_table.route_table_private_nat[0].id}"
+}
+
+resource "aws_route_table_association" "override_nat_route_private_subnets" {
+  for_each  = var.associate_existing_nat > 0 ? toset(aws_subnet.private.*.id): []
+  subnet_id = each.key
+  route_table_id = "${var.existing_private_nat_gateway_id}"
 }
 
 resource "aws_vpc_endpoint" "s3" {

--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,8 @@ resource "aws_route_table_association" "dynamic_nat_route_private_subnets" {
 resource "aws_route_table_association" "override_nat_route_private_subnets" {
   for_each  = var.associate_existing_nat > 0 ? toset(aws_subnet.private.*.id) : []
   subnet_id = each.key
-  route_table_id = "${var.existing_private_nat_gateway_id}"
+  route_table_id = "${aws_route_table.route_table_private_nat[0].id}"
+#  route_table_id = "${var.existing_private_nat_gateway_id}"
 }
 
 resource "aws_vpc_endpoint" "s3" {

--- a/main.tf
+++ b/main.tf
@@ -49,3 +49,15 @@ resource "aws_route_table_association" "route_public_subnets" {
   route_table_id = "${aws_route_table.route_table_ig_gw.id}"
 }
 
+resource "aws_eip" "private_nat_eip" {
+  count = "${var.private_subnet_count > 0 ? 1 : 0}"
+  vpc   = true
+}
+
+resource "aws_nat_gateway" "private_nat_gw" {
+  count = "${var.private_subnet_count > 0 ? 1 : 0}"
+  allocation_id = "${aws_eip.private_nat_eip[0].id}"
+  subnet_id = "${aws_subnet.public[0].id}"
+  depends_on = ["aws_internet_gateway.gw"]
+}
+

--- a/main.tf
+++ b/main.tf
@@ -50,19 +50,19 @@ resource "aws_route_table_association" "route_public_subnets" {
 }
 
 resource "aws_eip" "private_nat_eip" {
-  count = "${var.private_subnet_count > 0 ? 1 : 0}"
+  count = "${var.enable_nat > 0 ? 1 : 0}"
   vpc   = true
 }
 
 resource "aws_nat_gateway" "private_nat_gw" {
-  count = "${var.private_subnet_count > 0 ? 1 : 0}"
+  count = "${var.enable_nat > 0 ? 1 : 0}"
   allocation_id = "${aws_eip.private_nat_eip[0].id}"
   subnet_id = "${aws_subnet.public[0].id}"
   depends_on = ["aws_internet_gateway.gw"]
 }
 
 resource "aws_route_table" "route_table_private_nat" {
-  count = "${var.private_subnet_count > 0 ? 1 : 0}"
+  count = "${var.enable_nat > 0 ? 1 : 0}"
   vpc_id = "${aws_vpc.main.id}"
   route {
     cidr_block = "0.0.0.0/0"
@@ -71,7 +71,7 @@ resource "aws_route_table" "route_table_private_nat" {
 }
 
 resource "aws_route_table_association" "route_private_subnets" {
-  for_each = toset(aws_subnet.private.*.id)
+  for_each  = var.enable_nat > 0 ? toset(aws_subnet.private.*.id) : []
   subnet_id = each.key
   route_table_id = "${aws_route_table.route_table_private_nat[0].id}"
 }

--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,8 @@ resource "aws_route_table_association" "nat_route_private_subnets" {
 resource "aws_route_table_association" "override_nat_route_private_subnets" {
   for_each  = (var.associate_existing_nat > 0 ? toset(aws_subnet.private.*.id) : [])
   subnet_id = each.key
-  route_table_id = "${var.existing_private_nat_gateway_id}"
+  route_table_id = "${aws_route_table.route_table_private_nat[0].id}"
+#  route_table_id = "${var.existing_private_nat_gateway_id}"
 }
 
 resource "aws_vpc_endpoint" "s3" {

--- a/main.tf
+++ b/main.tf
@@ -77,7 +77,7 @@ resource "aws_route_table_association" "dynamic_nat_route_private_subnets" {
 }
 
 resource "aws_route_table_association" "override_nat_route_private_subnets" {
-  for_each  = var.associate_existing_nat > 0 ? toset(aws_subnet.private.*.id): []
+  for_each  = var.associate_existing_nat > 0 ? toset(aws_subnet.private.*.id) : []
   subnet_id = each.key
   route_table_id = "${var.existing_private_nat_gateway_id}"
 }

--- a/main.tf
+++ b/main.tf
@@ -76,12 +76,11 @@ resource "aws_route_table_association" "dynamic_nat_route_private_subnets" {
   route_table_id = "${aws_route_table.route_table_private_nat[0].id}"
 }
 
-resource "aws_route_table_association" "override_nat_route_private_subnets" {
-  for_each  = var.associate_existing_nat > 0 ? toset(aws_subnet.private.*.id) : []
-  subnet_id = each.key
-  route_table_id = "${aws_route_table.route_table_private_nat[0].id}"
+#resource "aws_route_table_association" "override_nat_route_private_subnets" {
+#  for_each  = var.associate_existing_nat > 0 ? toset(aws_subnet.private.*.id) : []
+#  subnet_id = each.key
 #  route_table_id = "${var.existing_private_nat_gateway_id}"
-}
+#}
 
 resource "aws_vpc_endpoint" "s3" {
   count        = "${var.create_vpc_endpoint > 0 ? 1 : 0}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,6 +2,11 @@ output "vpc_main_id" {
   value = "${aws_vpc.main.id}"
 }
 
-output "vpc_subnet_ids" {
+output "vpc_public_subnet_ids" {
   value = "${aws_subnet.public.*.id}"
 }
+
+output "vpc_private_subnet_ids" {
+  value = "${aws_subnet.private.*.id}"
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,9 @@ variable "vpc_cidr_block" {
   default = "10.0.0.0/24"
 }
 
-variable "subnet_init_value" {}
-variable "subnet_count" { default = 1 }
+variable "public_subnet_init_value" {}
+variable "public_subnet_count" { default = 1 }
+
+variable "private_subnet_init_value" {}
+variable "private_subnet_count" { default = 0 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -10,7 +10,7 @@ variable "private_subnet_count" { default = 0 }
 
 variable "enable_nat" { default = 0 }
 variable "associate_existing_nat" { default = 0 }
-variable "existing_private_nat_gateway_id" { default = "" }
+variable "existing_private_nat_gateway_id" { default = null }
 
 variable "vpc_endpoint" {}
 variable "create_vpc_endpoint" { default = 0 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,3 +8,5 @@ variable "public_subnet_count" { default = 1 }
 variable "private_subnet_init_value" {}
 variable "private_subnet_count" { default = 0 }
 
+variable "vpc_endpoint" {}
+variable "create_vpc_endpoint" { default = 0 }

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,8 @@ variable "private_subnet_init_value" {}
 variable "private_subnet_count" { default = 0 }
 
 variable "enable_nat" { default = 0 }
+variable "associate_existing_nat" { default = 0 }
+variable "existing_private_nat_gateway_id" { default = "" }
 
 variable "vpc_endpoint" {}
 variable "create_vpc_endpoint" { default = 0 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,8 @@ variable "public_subnet_count" { default = 1 }
 variable "private_subnet_init_value" {}
 variable "private_subnet_count" { default = 0 }
 
+variable "enable_nat" { default = 0 }
+
 variable "vpc_endpoint" {}
 variable "create_vpc_endpoint" { default = 0 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -10,7 +10,7 @@ variable "private_subnet_count" { default = 0 }
 
 variable "enable_nat" { default = 0 }
 variable "associate_existing_nat" { default = 0 }
-variable "existing_private_nat_gateway_id" { default = null }
+variable "existing_private_nat_gateway_id" { default = "nat-1234" }
 
 variable "vpc_endpoint" {}
 variable "create_vpc_endpoint" { default = 0 }

--- a/variables.tf
+++ b/variables.tf
@@ -10,3 +10,4 @@ variable "private_subnet_count" { default = 0 }
 
 variable "vpc_endpoint" {}
 variable "create_vpc_endpoint" { default = 0 }
+


### PR DESCRIPTION
*Summary of Changes*
* We currently have a use case where we want lambda to contact our local bucketeer servers. We can achieve this by making the lambda function use designated subnet(s) and create a NAT gateway. We can whitelist the elastic IP in which this NAT is attached to