### PR TITLE
[IIIF-460] Make a dedicated VPC endpoint route that bypasses NAT gateway when accessing S3 buckets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -86,6 +86,11 @@ resource "aws_vpc_endpoint" "s3" {
   count        = "${var.create_vpc_endpoint > 0 ? 1 : 0}"
   vpc_id       = "${aws_vpc.main.id}"
   service_name = "${var.vpc_endpoint}"
-  subnet_ids   = "${aws_subnet.private.*.id}"
+}
+
+resource "aws_vpc_endpoint_route_table_association" "endpoint_route_on_nat" {
+  count           = "${var.create_vpc_endpoint > 0 ? 1 : 0}"
+  route_table_id  = "${aws_route_table.route_table_private_nat[0].id}"
+  vpc_endpoint_id = "${aws_vpc_endpoint.s3[0].id}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -86,5 +86,6 @@ resource "aws_vpc_endpoint" "s3" {
   count        = "${var.create_vpc_endpoint > 0 ? 1 : 0}"
   vpc_id       = "${aws_vpc.main.id}"
   service_name = "${var.vpc_endpoint}"
+  subnet_ids   = "${aws_subnet.private.*.id}"
 }
 


### PR DESCRIPTION
**Summary of Changes**
* I forgot to add a route table where any outbound traffic that matches an S3 endpoint(oregon bucket in this case) will use the internal VPC endpoint instead of routing through the NAT gateway. This will save us $$$ because we're currently charged per GB for every TIFF read by Bucketeer Lambda.