### PR TITLE
[IIIF-699] EKS environment to use updated VPC module

### DIFF
--- a/.travis/terraform-validate.sh
+++ b/.travis/terraform-validate.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Module terraform validate script
 
-TERRAFORM_VERSION="0.12.6"
+TERRAFORM_VERSION="0.12.20"
 TERRAFORM_URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
 TERRAFORM_BIN="${HOME}/terraform/bin"
 TERRAFORM="${TERRAFORM_BIN}/terraform"

--- a/main.tf
+++ b/main.tf
@@ -71,8 +71,8 @@ resource "aws_eip" "private_nat_eip" {
 #############################################################################################################
 resource "aws_nat_gateway" "private_nat_gw" {
   count = "${var.enable_nat > 0 ? 1 : 0}"
-  allocation_id = "${aws_eip.private_nat_eip[0].id}"
-  subnet_id = "${aws_subnet.public[0].id}"
+  allocation_id = "${aws_eip.private_nat_eip[count.index].id}"
+  subnet_id = "${aws_subnet.public[count.index].id}"
   depends_on = ["aws_internet_gateway.gw"]
 }
 
@@ -84,7 +84,7 @@ resource "aws_route_table" "nat_egress_global" {
   vpc_id = "${aws_vpc.main.id}"
   route {
     cidr_block = "0.0.0.0/0"
-    nat_gateway_id = "${aws_nat_gateway.private_nat_gw[0].id}"
+    nat_gateway_id = "${aws_nat_gateway.private_nat_gw[count.index].id}"
   }
 }
 
@@ -95,5 +95,5 @@ resource "aws_route_table" "nat_egress_global" {
 resource "aws_route_table_association" "nat_route_private_subnets" {
   for_each  = (var.force_nat_egress > 0 ? toset(aws_subnet.private.*.id) : [])
   subnet_id = each.key
-  route_table_id = "${aws_route_table.nat_egress_global[0].id}"
+  route_table_id = "${aws_route_table.nat_egress_global[count.index].id}"
 }

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ data "aws_availability_zones" "available" {}
 # Create VPC network
 #############################################################################################################
 resource "aws_vpc" "main" {
-  cidr_block = var.vpc_cidr_block
+  cidr_block              = var.vpc_cidr_block
 }
 
 #############################################################################################################
@@ -23,10 +23,10 @@ resource "aws_subnet" "public" {
 # Create private subnets to attach Internet Gateway route
 #############################################################################################################
 resource "aws_subnet" "private" {
-  count                   = "${var.private_subnet_count}"
-  vpc_id                  = "${aws_vpc.main.id}"
-  cidr_block              = "${cidrsubnet(aws_vpc.main.cidr_block, 8, var.private_subnet_init_value + count.index)}"
-  availability_zone       = "${data.aws_availability_zones.available.names[count.index]}"
+  count                   = var.private_subnet_count
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(aws_vpc.main.cidr_block, 8, var.private_subnet_init_value + count.index)
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
   map_public_ip_on_launch = false
 }
 
@@ -34,17 +34,17 @@ resource "aws_subnet" "private" {
 # Attach internet gateway to created VPC
 #############################################################################################################
 resource "aws_internet_gateway" "gw" {
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id                  = aws_vpc.main.id
 }
 
 #############################################################################################################
 # Create a egress global route table for the public subnet to associate
 #############################################################################################################
 resource "aws_route_table" "egress_global" {
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id                  = aws_vpc.main.id
   route {
-    cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.gw.id}"
+    cidr_block            = "0.0.0.0/0"
+    gateway_id            = aws_internet_gateway.gw.id
   }
 }
 
@@ -52,17 +52,17 @@ resource "aws_route_table" "egress_global" {
 # Assocate route table containing IGW egress access to public subnets
 #############################################################################################################
 resource "aws_route_table_association" "route_public_subnets" {
-  for_each = toset(aws_subnet.public.*.id)
-  subnet_id = each.key
-  route_table_id = "${aws_route_table.egress_global.id}"
+  for_each                = toset(aws_subnet.public.*.id)
+  subnet_id               = each.key
+  route_table_id          = aws_route_table.egress_global.id
 }
 
 #############################################################################################################
 # If nat flag set reverse an elastic IP 
 #############################################################################################################
 resource "aws_eip" "private_nat_eip" {
-  count = "${var.enable_nat > 0 ? 1 : 0}"
-  vpc   = true
+  count                   = var.enable_nat > 0 ? 1 : 0
+  vpc                     = true
 }
 
 #############################################################################################################
@@ -70,30 +70,30 @@ resource "aws_eip" "private_nat_eip" {
 # The gateway will be running on the public subnet and has egress access to the world through the IGW
 #############################################################################################################
 resource "aws_nat_gateway" "private_nat_gw" {
-  count = "${var.enable_nat > 0 ? 1 : 0}"
-  allocation_id = "${aws_eip.private_nat_eip[count.index].id}"
-  subnet_id = "${aws_subnet.public[count.index].id}"
-  depends_on = ["aws_internet_gateway.gw"]
+  count                   = var.enable_nat > 0 ? 1 : 0
+  allocation_id           = aws_eip.private_nat_eip[count.index].id
+  subnet_id               = aws_subnet.public[count.index].id
+  depends_on              = [aws_internet_gateway.gw]
 }
 
 #############################################################################################################
 # If nat flag set, create a route table to route all egress traffic to use the NAT gateway
 #############################################################################################################
 resource "aws_route_table" "nat_egress_global" {
-  count = "${var.enable_nat > 0 ? 1 : 0}"
-  vpc_id = "${aws_vpc.main.id}"
+  count                   = var.enable_nat > 0 ? 1 : 0
+  vpc_id                  = aws_vpc.main.id
   route {
-    cidr_block = "0.0.0.0/0"
-    nat_gateway_id = "${aws_nat_gateway.private_nat_gw[count.index].id}"
+    cidr_block            = "0.0.0.0/0"
+    nat_gateway_id        = aws_nat_gateway.private_nat_gw[count.index].id
   }
 }
 
 #############################################################################################################
 # If force_nat_egress set, associate the global NAT egress route table to the private subnets
-# WARNING: This can get expensive if you're unsure what your egress traffic looks like
+# WARNING                 : This can get expensive if you're unsure what your egress traffic looks like
 #############################################################################################################
 resource "aws_route_table_association" "nat_route_private_subnets" {
-  for_each  = (var.force_nat_egress > 0 ? toset(aws_subnet.private.*.id) : [])
-  subnet_id = each.key
-  route_table_id = "${aws_route_table.nat_egress_global[0].id}"
+  for_each                = (var.force_nat_egress > 0 ? toset(aws_subnet.private.*.id) : [])
+  subnet_id               = each.key
+  route_table_id          = aws_route_table.nat_egress_global[0].id
 }

--- a/main.tf
+++ b/main.tf
@@ -5,17 +5,17 @@ data "aws_availability_zones" "available" {}
 # Create VPC network
 #############################################################################################################
 resource "aws_vpc" "main" {
-  cidr_block = "${var.vpc_cidr_block}"
+  cidr_block = var.vpc_cidr_block
 }
 
 #############################################################################################################
 # Create public subnet to attach Internet Gateway route
 #############################################################################################################
 resource "aws_subnet" "public" {
-  count                   = "${var.public_subnet_count}"
-  vpc_id                  = "${aws_vpc.main.id}"
-  cidr_block              = "${cidrsubnet(aws_vpc.main.cidr_block, 8, var.public_subnet_init_value + count.index)}"
-  availability_zone       = "${data.aws_availability_zones.available.names[count.index]}"
+  count                   = var.public_subnet_count
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(aws_vpc.main.cidr_block, 8, var.public_subnet_init_value + count.index)
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
   map_public_ip_on_launch = true
 }
 

--- a/main.tf
+++ b/main.tf
@@ -93,6 +93,7 @@ resource "aws_route_table" "nat_egress_global" {
 # WARNING: This can get expensive if you're unsure what your egress traffic looks like
 #############################################################################################################
 resource "aws_route_table_association" "nat_route_private_subnets" {
+  count = "${var.force_nat_egress > 0 ? 1 : 0}"
   for_each  = (var.force_nat_egress > 0 ? toset(aws_subnet.private.*.id) : [])
   subnet_id = each.key
   route_table_id = "${aws_route_table.nat_egress_global[count.index].id}"

--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ resource "aws_route_table" "egress_global" {
 # Assocate route table containing IGW egress access to public subnets
 #############################################################################################################
 resource "aws_route_table_association" "route_public_subnets" {
-  for_each = toset(aws_subnet.public.*.id)
+  for_each = aws_subnet.public.*.id
   subnet_id = each.key
   route_table_id = "${aws_route_table.egress_global.id}"
 }

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,10 @@ data "aws_availability_zones" "available" {}
 #############################################################################################################
 resource "aws_vpc" "main" {
   cidr_block              = var.vpc_cidr_block
+
+  tags                    = {
+    Name                  = var.default_tag
+  }
 }
 
 #############################################################################################################
@@ -17,6 +21,10 @@ resource "aws_subnet" "public" {
   cidr_block              = cidrsubnet(aws_vpc.main.cidr_block, 8, var.public_subnet_init_value + count.index)
   availability_zone       = data.aws_availability_zones.available.names[count.index]
   map_public_ip_on_launch = true
+
+  tags                    = {
+    Name                  = var.default_tag
+  }
 }
 
 #############################################################################################################
@@ -28,6 +36,10 @@ resource "aws_subnet" "private" {
   cidr_block              = cidrsubnet(aws_vpc.main.cidr_block, 8, var.private_subnet_init_value + count.index)
   availability_zone       = data.aws_availability_zones.available.names[count.index]
   map_public_ip_on_launch = false
+
+  tags                    = {
+    Name                  = var.default_tag
+  }
 }
 
 #############################################################################################################
@@ -35,6 +47,10 @@ resource "aws_subnet" "private" {
 #############################################################################################################
 resource "aws_internet_gateway" "gw" {
   vpc_id                  = aws_vpc.main.id
+
+  tags                    = {
+    Name                  = var.default_tag
+  }
 }
 
 #############################################################################################################
@@ -45,6 +61,10 @@ resource "aws_route_table" "egress_global" {
   route {
     cidr_block            = "0.0.0.0/0"
     gateway_id            = aws_internet_gateway.gw.id
+  }
+
+  tags                    = {
+    Name                  = var.default_tag
   }
 }
 
@@ -63,6 +83,10 @@ resource "aws_route_table_association" "route_public_subnets" {
 resource "aws_eip" "private_nat_eip" {
   count                   = var.enable_nat > 0 ? 1 : 0
   vpc                     = true
+
+  tags                    = {
+    Name                  = var.default_tag
+  }
 }
 
 #############################################################################################################
@@ -74,6 +98,10 @@ resource "aws_nat_gateway" "private_nat_gw" {
   allocation_id           = aws_eip.private_nat_eip[count.index].id
   subnet_id               = aws_subnet.public[count.index].id
   depends_on              = [aws_internet_gateway.gw]
+
+  tags                    = {
+    Name                  = var.default_tag
+  }
 }
 
 #############################################################################################################
@@ -85,6 +113,10 @@ resource "aws_route_table" "nat_egress_global" {
   route {
     cidr_block            = "0.0.0.0/0"
     nat_gateway_id        = aws_nat_gateway.private_nat_gw[count.index].id
+  }
+
+  tags                    = {
+    Name                  = var.default_tag
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -95,5 +95,5 @@ resource "aws_route_table" "nat_egress_global" {
 resource "aws_route_table_association" "nat_route_private_subnets" {
   for_each  = (var.force_nat_egress > 0 ? toset(aws_subnet.private.*.id) : [])
   subnet_id = each.key
-  route_table_id = "${aws_route_table.nat_egress_global.id}"
+  route_table_id = "${aws_route_table.nat_egress_global[count.index].id}"
 }

--- a/main.tf
+++ b/main.tf
@@ -95,5 +95,5 @@ resource "aws_route_table" "nat_egress_global" {
 resource "aws_route_table_association" "nat_route_private_subnets" {
   for_each  = (var.force_nat_egress > 0 ? toset(aws_subnet.private.*.id) : [])
   subnet_id = each.key
-  route_table_id = "${aws_route_table.nat_egress_global[count.index].id}"
+  route_table_id = "${aws_route_table.nat_egress_global.id}"
 }

--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ resource "aws_route_table" "egress_global" {
 # Assocate route table containing IGW egress access to public subnets
 #############################################################################################################
 resource "aws_route_table_association" "route_public_subnets" {
-  for_each = aws_subnet.public.*.id
+  for_each = toset(aws_subnet.public.*.id)
   subnet_id = each.key
   route_table_id = "${aws_route_table.egress_global.id}"
 }

--- a/main.tf
+++ b/main.tf
@@ -93,8 +93,7 @@ resource "aws_route_table" "nat_egress_global" {
 # WARNING: This can get expensive if you're unsure what your egress traffic looks like
 #############################################################################################################
 resource "aws_route_table_association" "nat_route_private_subnets" {
-  count = "${var.force_nat_egress > 0 ? 1 : 0}"
   for_each  = (var.force_nat_egress > 0 ? toset(aws_subnet.private.*.id) : [])
   subnet_id = each.key
-  route_table_id = "${aws_route_table.nat_egress_global[count.index].id}"
+  route_table_id = "${aws_route_table.nat_egress_global[0].id}"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,4 @@
 # Populate state file with AZ info.
-
 data "aws_availability_zones" "available" {}
 
 #############################################################################################################
@@ -20,6 +19,9 @@ resource "aws_subnet" "public" {
   map_public_ip_on_launch = true
 }
 
+#############################################################################################################
+# Create private subnets to attach Internet Gateway route
+#############################################################################################################
 resource "aws_subnet" "private" {
   count                   = "${var.private_subnet_count}"
   vpc_id                  = "${aws_vpc.main.id}"
@@ -35,7 +37,10 @@ resource "aws_internet_gateway" "gw" {
   vpc_id = "${aws_vpc.main.id}"
 }
 
-resource "aws_route_table" "route_table_ig_gw" {
+#############################################################################################################
+# Create a egress global route table for the public subnet to associate
+#############################################################################################################
+resource "aws_route_table" "egress_global" {
   vpc_id = "${aws_vpc.main.id}"
   route {
     cidr_block = "0.0.0.0/0"
@@ -43,17 +48,27 @@ resource "aws_route_table" "route_table_ig_gw" {
   }
 }
 
+#############################################################################################################
+# Assocate route table containing IGW egress access to public subnets
+#############################################################################################################
 resource "aws_route_table_association" "route_public_subnets" {
   for_each = toset(aws_subnet.public.*.id)
   subnet_id = each.key
-  route_table_id = "${aws_route_table.route_table_ig_gw.id}"
+  route_table_id = "${aws_route_table.egress_global.id}"
 }
 
+#############################################################################################################
+# If nat flag set reverse an elastic IP 
+#############################################################################################################
 resource "aws_eip" "private_nat_eip" {
   count = "${var.enable_nat > 0 ? 1 : 0}"
   vpc   = true
 }
 
+#############################################################################################################
+# If nat flag set, create a NAT gateway.
+# The gateway will be running on the public subnet and has egress access to the world through the IGW
+#############################################################################################################
 resource "aws_nat_gateway" "private_nat_gw" {
   count = "${var.enable_nat > 0 ? 1 : 0}"
   allocation_id = "${aws_eip.private_nat_eip[0].id}"
@@ -61,7 +76,10 @@ resource "aws_nat_gateway" "private_nat_gw" {
   depends_on = ["aws_internet_gateway.gw"]
 }
 
-resource "aws_route_table" "route_table_private_nat" {
+#############################################################################################################
+# If nat flag set, create a route table to route all egress traffic to use the NAT gateway
+#############################################################################################################
+resource "aws_route_table" "nat_egress_global" {
   count = "${var.enable_nat > 0 ? 1 : 0}"
   vpc_id = "${aws_vpc.main.id}"
   route {
@@ -70,27 +88,21 @@ resource "aws_route_table" "route_table_private_nat" {
   }
 }
 
+#############################################################################################################
+# If force_nat_egress set, associate the global NAT egress route table to the private subnets
+# WARNING: This can get expensive if you're unsure what your egress traffic looks like
+#############################################################################################################
 resource "aws_route_table_association" "nat_route_private_subnets" {
-  for_each  = (var.enable_nat > 0 ? toset(aws_subnet.private.*.id) : [])
+  for_each  = (var.force_nat_egress > 0 ? toset(aws_subnet.private.*.id) : [])
   subnet_id = each.key
-  route_table_id = "${aws_route_table.route_table_private_nat[0].id}"
+  route_table_id = "${aws_route_table.nat_egress_global[0].id}"
 }
 
-resource "aws_route_table_association" "override_nat_route_private_subnets" {
-  for_each  = (var.associate_existing_nat > 0 ? toset(aws_subnet.private.*.id) : [])
-  subnet_id = each.key
-  route_table_id = "${var.existing_private_nat_gateway_id != "" ? var.existing_private_nat_gateway_id : aws_route_table.route_table_private_nat[0].id}"
-}
-
+#############################################################################################################
+# Create VPC endpoints
+#############################################################################################################
 resource "aws_vpc_endpoint" "s3" {
   count        = "${var.create_vpc_endpoint > 0 ? 1 : 0}"
   vpc_id       = "${aws_vpc.main.id}"
   service_name = "${var.vpc_endpoint}"
 }
-
-resource "aws_vpc_endpoint_route_table_association" "endpoint_route_on_nat" {
-  count           = "${var.create_vpc_endpoint > 0 ? 1 : 0}"
-  route_table_id  = "${aws_route_table.route_table_private_nat[0].id}"
-  vpc_endpoint_id = "${aws_vpc_endpoint.s3[0].id}"
-}
-

--- a/main.tf
+++ b/main.tf
@@ -97,12 +97,3 @@ resource "aws_route_table_association" "nat_route_private_subnets" {
   subnet_id = each.key
   route_table_id = "${aws_route_table.nat_egress_global[0].id}"
 }
-
-#############################################################################################################
-# Create VPC endpoints
-#############################################################################################################
-resource "aws_vpc_endpoint" "s3" {
-  count        = "${var.create_vpc_endpoint > 0 ? 1 : 0}"
-  vpc_id       = "${aws_vpc.main.id}"
-  service_name = "${var.vpc_endpoint}"
-}

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,10 +15,9 @@ output "public_egress_route_table_id" {
 }
 
 output "private_nat_egress_route_table_id" {
-  value = "${aws_route_table.nat_egress_global[0].id}"
+  value = "${aws_route_table.nat_egress_global[count.index].id}"
 }
 
 output "private_nat_gateway_id" {
-  value = "${aws_nat_gateway.private_nat_gw[0].id}"
+  value = "${aws_nat_gateway.private_nat_gw[count.index].id}"
 }
-

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,12 +10,12 @@ output "vpc_private_subnet_ids" {
   value = "${aws_subnet.private.*.id}"
 }
 
-output "public_network_route_table_id" {
-  value = "${aws_route_table.route_table_ig_gw.id}"
+output "public_egress_route_table_id" {
+  value = "${aws_route_table.egress_global.id}"
 }
 
-output "private_network_route_table_id" {
-  value = "${aws_route_table.route_table_private_nat[0].id}"
+output "private_nat_egress_route_table_id" {
+  value = "${aws_route_table.nat_egress_global[0].id}"
 }
 
 output "private_nat_gateway_id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,9 +15,9 @@ output "public_egress_route_table_id" {
 }
 
 output "private_nat_egress_route_table_id" {
-  value = length(aws_route_table.nat_egress_global.this) > 0 ? aws_route_table.nat_egress_global[0].id: null
+  value = length(aws_route_table.nat_egress_global) > 0 ? aws_route_table.nat_egress_global[0].id: null
 }
 
 output "private_nat_gateway_id" {
-  value = length(aws_nat_gateway.private_nat_gw.this) > 0 ? aws_nat_gateway.private_nat_gw[0].id: null
+  value = length(aws_nat_gateway.private_nat_gw) > 0 ? aws_nat_gateway.private_nat_gw[0].id: null
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,17 +1,17 @@
 output "vpc_main_id" {
-  value = "${aws_vpc.main.id}"
+  value = aws_vpc.main.id
 }
 
 output "vpc_public_subnet_ids" {
-  value = "${aws_subnet.public.*.id}"
+  value = aws_subnet.public.*.id
 }
 
 output "vpc_private_subnet_ids" {
-  value = "${aws_subnet.private.*.id}"
+  value = aws_subnet.private.*.id
 }
 
 output "public_egress_route_table_id" {
-  value = "${aws_route_table.egress_global.id}"
+  value = aws_route_table.egress_global.id
 }
 
 output "private_nat_egress_route_table_id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,9 +15,9 @@ output "public_egress_route_table_id" {
 }
 
 output "private_nat_egress_route_table_id" {
-  value = "${aws_route_table.nat_egress_global[count.index].id}"
+  value = length(aws_route_table.nat_egress_global.this) > 0 ? aws_route_table.nat_egress_global[0].id: null
 }
 
 output "private_nat_gateway_id" {
-  value = "${aws_nat_gateway.private_nat_gw[count.index].id}"
+  value = length(aws_nat_gateway.private_nat_gw.this) > 0 ? aws_nat_gateway.private_nat_gw[0].id: null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -10,7 +10,3 @@ variable "private_subnet_count" { default = 0 }
 
 variable "enable_nat" { default = 0 }
 variable "force_nat_egress" { default = 0 }
-
-variable "vpc_endpoint" {}
-variable "create_vpc_endpoint" { default = 0 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,10 @@ variable "vpc_cidr_block" {
   default = "10.0.0.0/16"
 }
 
+variable "default_tag" {
+  default = "VPC-Terraform"
+}
+
 variable "public_subnet_init_value" {}
 variable "public_subnet_count" {
   default = 1

--- a/variables.tf
+++ b/variables.tf
@@ -3,10 +3,18 @@ variable "vpc_cidr_block" {
 }
 
 variable "public_subnet_init_value" {}
-variable "public_subnet_count" { default = 1 }
+variable "public_subnet_count" {
+  default = 1
+}
 
 variable "private_subnet_init_value" {}
-variable "private_subnet_count" { default = 0 }
+variable "private_subnet_count" {
+  default = 0
+}
 
-variable "enable_nat" { default = 0 }
-variable "force_nat_egress" { default = 0 }
+variable "enable_nat" {
+  default = 0
+}
+variable "force_nat_egress" {
+  default = 0
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 variable "vpc_cidr_block" {
-  default = "10.0.0.0/24"
+  default = "10.0.0.0/16"
 }
 
 variable "public_subnet_init_value" {}
@@ -9,8 +9,7 @@ variable "private_subnet_init_value" {}
 variable "private_subnet_count" { default = 0 }
 
 variable "enable_nat" { default = 0 }
-variable "associate_existing_nat" { default = 0 }
-variable "existing_private_nat_gateway_id" { default = "nat-1234" }
+variable "force_nat_egress" { default = 0 }
 
 variable "vpc_endpoint" {}
 variable "create_vpc_endpoint" { default = 0 }


### PR DESCRIPTION
The EKS environment will be reusing this VPC module. I removed some features to make the module more portable. The new module will create default public/private subnets. I've removed the VPC endpoint feature as that should ideally be managed outside of the module to keep this more reusable.

EDIT: also updated module to be compatible with Terraform 0.12.20